### PR TITLE
Potential fix for code scanning alert no. 26: Insecure randomness

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -131,10 +131,37 @@ async function apiPost<T>(path: string): Promise<T> {
   return res.json() as Promise<T>
 }
 
+// Generate a cryptographically secure random suffix consisting of
+// lowercase alphanumeric characters, similar to Math.random().toString(36).
+function generateRandomIdSuffix(length: number): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
+  const alphabetLength = alphabet.length
+  const bytes = new Uint8Array(length)
+
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    crypto.getRandomValues(bytes)
+  } else if (typeof window !== 'undefined' && window.crypto && typeof window.crypto.getRandomValues === 'function') {
+    window.crypto.getRandomValues(bytes)
+  } else {
+    // Fallback for environments without crypto; not cryptographically secure.
+    for (let i = 0; i < length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256)
+    }
+  }
+
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += alphabet[bytes[i] % alphabetLength]
+  }
+  return result
+}
+
 let _tabId: string | null = null
 function getTabId(): string {
   if (!_tabId) {
-    _tabId = sessionStorage.getItem('tabId') ?? `tab-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    _tabId =
+      sessionStorage.getItem('tabId') ??
+      `tab-${Date.now()}-${generateRandomIdSuffix(6)}`
     sessionStorage.setItem('tabId', _tabId)
   }
   return _tabId
@@ -143,7 +170,9 @@ function getTabId(): string {
 let _sessionId: string | null = null
 function getSessionId(): string {
   if (!_sessionId) {
-    _sessionId = localStorage.getItem('sessionId') ?? `sess-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    _sessionId =
+      localStorage.getItem('sessionId') ??
+      `sess-${Date.now()}-${generateRandomIdSuffix(6)}`
     localStorage.setItem('sessionId', _sessionId)
   }
   return _sessionId


### PR DESCRIPTION
Potential fix for [https://github.com/ahmetcagriakca/vezir/security/code-scanning/26](https://github.com/ahmetcagriakca/vezir/security/code-scanning/26)

In general, the fix is to replace `Math.random()` with a cryptographically secure random generator when creating any identifier that is sent to the server and might be used as a session or correlation token. In browser environments, `crypto.getRandomValues` is the standard secure API and does not require extra dependencies.

The best targeted fix here is to introduce a small helper function in `frontend/src/api/client.ts` that generates a secure random string using `crypto.getRandomValues`, and then use that helper in both `getTabId()` and `getSessionId()` instead of `Math.random().toString(36)...`. This preserves the existing format of the IDs (a fixed prefix plus a short alphanumeric suffix) while switching the entropy source to a CSPRNG. We don’t need to change any call sites, and the IDs will still be stored and reused from Web Storage as before.

Concretely:
- Add a function (e.g., `generateRandomIdSuffix(length: number): string`) above `getTabId` that:
  - Creates a `Uint8Array` of `length` bytes.
  - Fills it with `crypto.getRandomValues`.
  - Maps bytes to URL-safe characters (e.g., `[0-9a-z]`) to match the existing base36-like suffix.
- Update the `_tabId` initializer expression so that when it falls back to generating a new ID, it uses `` `tab-${Date.now()}-${generateRandomIdSuffix(6)}` `` instead of `Math.random().toString(36).slice(2, 8)`.
- Similarly, update the `_sessionId` expression to use `` `sess-${Date.now()}-${generateRandomIdSuffix(6)}` ``.
- No imports are needed; `crypto`/`window.crypto` is available globally in the browser context. To support environments where `crypto` might not exist (e.g., some tests), we can optionally fall back to `Math.random()` only if secure crypto is unavailable, but the primary path should use `crypto.getRandomValues`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
