### PR TITLE
[S23-23.1] status-sync full project-field mutation

### DIFF
--- a/.github/workflows/status-sync.yml
+++ b/.github/workflows/status-sync.yml
@@ -8,6 +8,7 @@ permissions:
   issues: read
   pull-requests: read
   repository-projects: write
+  contents: read
 
 jobs:
   sync-status:
@@ -102,6 +103,117 @@ jobs:
             }
           ' -f projectId="$PROJECT_ID" 2>/dev/null || true)
 
-          echo "Field data retrieved. Status update logged."
-          echo "Note: Full GraphQL status field mutation requires project field IDs."
-          echo "For MVP, status is logged. Full automation in future iteration."
+          if [ -z "$FIELD_DATA" ]; then
+            echo "ERROR: Could not retrieve project field data."
+            exit 1
+          fi
+
+          # Extract Status field ID
+          STATUS_FIELD_ID=$(echo "$FIELD_DATA" | jq -r '
+            .data.node.fields.nodes[]
+            | select(.name == "Status")
+            | .id' 2>/dev/null || true)
+
+          if [ -z "$STATUS_FIELD_ID" ] || [ "$STATUS_FIELD_ID" = "null" ]; then
+            echo "ERROR: Status field not found in project. Available fields:"
+            echo "$FIELD_DATA" | jq -r '.data.node.fields.nodes[] | select(.name != null) | .name' 2>/dev/null
+            exit 1
+          fi
+
+          echo "Status field ID: $STATUS_FIELD_ID"
+
+          # Extract option ID for target status
+          OPTION_ID=$(echo "$FIELD_DATA" | jq -r --arg status "$STATUS" '
+            .data.node.fields.nodes[]
+            | select(.name == "Status")
+            | .options[]
+            | select(.name == $status)
+            | .id' 2>/dev/null || true)
+
+          if [ -z "$OPTION_ID" ] || [ "$OPTION_ID" = "null" ]; then
+            echo "ERROR: Status option '$STATUS' not found. Available options:"
+            echo "$FIELD_DATA" | jq -r '.data.node.fields.nodes[] | select(.name == "Status") | .options[] | .name' 2>/dev/null
+            exit 1
+          fi
+
+          echo "Option ID for '$STATUS': $OPTION_ID"
+
+          # Get the project item ID for this issue
+          ISSUE_NODE_ID=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $number) { id }
+              }
+            }
+          ' -f owner="${GITHUB_REPOSITORY_OWNER}" -f repo="${GITHUB_REPOSITORY#*/}" \
+            -F number="$ISSUE_NUMBER" \
+            --jq '.data.repository.issue.id' 2>/dev/null || true)
+
+          if [ -z "$ISSUE_NODE_ID" ] || [ "$ISSUE_NODE_ID" = "null" ]; then
+            echo "ERROR: Could not get node ID for issue #$ISSUE_NUMBER."
+            exit 1
+          fi
+
+          # Find the item in the project
+          ITEM_ID=$(gh api graphql -f query='
+            query($projectId: ID!) {
+              node(id: $projectId) {
+                ... on ProjectV2 {
+                  items(first: 100) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue { id }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" \
+            --jq --arg issueId "$ISSUE_NODE_ID" \
+            '.data.node.items.nodes[] | select(.content.id == $issueId) | .id' 2>/dev/null || true)
+
+          if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+            echo "WARN: Issue #$ISSUE_NUMBER not found in project. Adding it first..."
+
+            ITEM_ID=$(gh api graphql -f query='
+              mutation($projectId: ID!, $contentId: ID!) {
+                addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+                  item { id }
+                }
+              }
+            ' -f projectId="$PROJECT_ID" -f contentId="$ISSUE_NODE_ID" \
+              --jq '.data.addProjectV2ItemById.item.id' 2>/dev/null || true)
+
+            if [ -z "$ITEM_ID" ] || [ "$ITEM_ID" = "null" ]; then
+              echo "ERROR: Failed to add issue #$ISSUE_NUMBER to project."
+              exit 1
+            fi
+            echo "Added issue #$ISSUE_NUMBER to project. Item ID: $ITEM_ID"
+          fi
+
+          echo "Project item ID: $ITEM_ID"
+
+          # Execute the mutation
+          RESULT=$(gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { singleSelectOptionId: $optionId }
+              }) {
+                projectV2Item { id }
+              }
+            }
+          ' -f projectId="$PROJECT_ID" -f itemId="$ITEM_ID" \
+            -f fieldId="$STATUS_FIELD_ID" -f optionId="$OPTION_ID" 2>&1)
+
+          if echo "$RESULT" | jq -e '.data.updateProjectV2ItemFieldValue.projectV2Item.id' >/dev/null 2>&1; then
+            echo "SUCCESS: Issue #$ISSUE_NUMBER status updated to '$STATUS' on Project V2."
+          else
+            echo "ERROR: Mutation failed."
+            echo "$RESULT"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Complete the partial status-sync.yml workflow (S20 governance debt)
- Extract Status field ID and option IDs from Project V2 GraphQL query
- Execute updateProjectV2ItemFieldValue mutation on PR events
- Auto-add issue to project if not already present
- Error handling with descriptive messages

## Test Plan
- [ ] PR opened → linked issue status set to "In Progress"
- [ ] PR merged → status set to "Done"
- [ ] PR closed (not merged) → status set to "Todo"
- [ ] Missing field/option → graceful error with log

Closes #100