### PR TITLE
[S23-23.1] fix: add --repo flag to status-sync gh issue list

### DIFF
--- a/.github/workflows/status-sync.yml
+++ b/.github/workflows/status-sync.yml
@@ -54,7 +54,8 @@ jobs:
           TASK_ID=$(echo "$ISSUE_REF" | grep -oP 'S\d+-\K[\d.]+\w*')
           SEARCH="${ISSUE_REF}"
 
-          ISSUE_NUMBER=$(gh issue list --search "$SEARCH in:title" --json number,title --limit 5 \
+          REPO="${GITHUB_REPOSITORY}"
+          ISSUE_NUMBER=$(gh issue list --repo "$REPO" --search "$SEARCH in:title" --json number,title --limit 5 \
             --jq ".[] | select(.title | contains(\"$SEARCH\")) | .number" | head -1 || true)
 
           if [ -z "$ISSUE_NUMBER" ]; then


### PR DESCRIPTION
## Summary
Fix status-sync workflow bug: `gh issue list` fails with "failed to run git" because workflow runs without `actions/checkout`. Adding `--repo` flag provides explicit repository context.

## Test Plan
- [ ] status-sync workflow can find issues by [SN-N.M] pattern on PR events
- [ ] Merge event correctly identifies linked issue and sets status to "Done"

Closes #100 (remaining fix)