### PR TITLE
[S23-23.1] fix: PROJECT_TOKEN for Project V2 write access

### DIFF
--- a/.github/workflows/status-sync.yml
+++ b/.github/workflows/status-sync.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Extract linked issue and update status
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN != '' && secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_STATE: ${{ github.event.pull_request.state }}


### PR DESCRIPTION
## Summary
Use PROJECT_TOKEN secret for Project V2 write access. GITHUB_TOKEN cannot access Project V2 fields (GitHub limitation). Falls back to GITHUB_TOKEN when PROJECT_TOKEN not set.

## Test Plan
- [ ] With PROJECT_TOKEN: status-sync finds project and updates field
- [ ] Without PROJECT_TOKEN: graceful "No project found" skip (existing behavior)

**Operator action required:** Create a fine-grained PAT with `project:write` permission and add it as `PROJECT_TOKEN` repo secret.