### PR TITLE
[S25-25.3] Frontend Vitest component test baseline

### DIFF
--- a/frontend/src/__tests__/FreshnessIndicator.test.tsx
+++ b/frontend/src/__tests__/FreshnessIndicator.test.tsx
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { FreshnessIndicator } from '../components/FreshnessIndicator'
+import type { SourceInfo } from '../types/api'
+
+describe('FreshnessIndicator', () => {
+  const defaultProps = {
+    freshnessMs: 5000,
+    sourcesUsed: [{ name: 'state.json', freshness: 'fresh' }] as SourceInfo[],
+    sourcesMissing: [] as string[],
+    lastFetchedAt: null,
+  }
+
+  test('renders data age in seconds format', () => {
+    render(<FreshnessIndicator {...defaultProps} freshnessMs={30000} />)
+    expect(screen.getByText('30s ago')).toBeTruthy()
+  })
+
+  test('renders data age in minutes format', () => {
+    render(<FreshnessIndicator {...defaultProps} freshnessMs={300000} />)
+    expect(screen.getByText('5m ago')).toBeTruthy()
+  })
+
+  test('shows stale warning when threshold exceeded', () => {
+    const { container } = render(
+      <FreshnessIndicator {...defaultProps} freshnessMs={60000} staleThresholdMs={30000} />
+    )
+    expect(container.querySelector('.border-red-500\\/50')).toBeTruthy()
+  })
+
+  test('shows sources used', () => {
+    render(<FreshnessIndicator {...defaultProps} />)
+    expect(screen.getByText('state.json')).toBeTruthy()
+  })
+
+  test('shows missing sources', () => {
+    render(
+      <FreshnessIndicator {...defaultProps} sourcesMissing={['mission.json']} />
+    )
+    expect(screen.getByText(/Missing.*mission\.json/)).toBeTruthy()
+  })
+})

--- a/frontend/src/__tests__/MissionStateBadge.test.tsx
+++ b/frontend/src/__tests__/MissionStateBadge.test.tsx
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MissionStateBadge } from '../components/MissionStateBadge'
+
+describe('MissionStateBadge', () => {
+  test('renders state label with underscores replaced by spaces', () => {
+    render(<MissionStateBadge state="gate_check" />)
+    expect(screen.getByText('gate check')).toBeTruthy()
+  })
+
+  test('renders completed state with green styling', () => {
+    const { container } = render(<MissionStateBadge state="completed" />)
+    const badge = container.querySelector('span')
+    expect(badge?.className).toContain('bg-green-600')
+  })
+
+  test('renders failed state with red styling', () => {
+    const { container } = render(<MissionStateBadge state="failed" />)
+    const badge = container.querySelector('span')
+    expect(badge?.className).toContain('bg-red-600')
+  })
+
+  test('renders unknown state with fallback gray', () => {
+    const { container } = render(<MissionStateBadge state="unknown_state" />)
+    const badge = container.querySelector('span')
+    expect(badge?.className).toContain('bg-gray-600')
+    expect(screen.getByText('unknown state')).toBeTruthy()
+  })
+
+  test('renders all known states without error', () => {
+    const states = ['pending', 'planning', 'executing', 'gate_check', 'rework',
+                    'approval_wait', 'completed', 'failed', 'aborted', 'timed_out']
+    for (const state of states) {
+      const { unmount } = render(<MissionStateBadge state={state} />)
+      expect(screen.getByText(state.replace(/_/g, ' '))).toBeTruthy()
+      unmount()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- 10 new component tests (MissionStateBadge + FreshnessIndicator)
- Total frontend tests: 39 (was 29)
- Type-safe props matching API contract

## Test Plan
- [x] vitest run: 39 tests PASS
- [x] tsc --noEmit: 0 errors