### PR TITLE
[S26-26.5] Frontend component test expansion

### DIFF
--- a/frontend/src/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,64 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ConfirmDialog } from '../components/ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  const defaultProps = {
+    open: true,
+    title: 'Delete Mission',
+    message: 'Are you sure?',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  test('renders nothing when closed', () => {
+    const { container } = render(<ConfirmDialog {...defaultProps} open={false} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  test('renders title and message when open', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    expect(screen.getByText('Delete Mission')).toBeTruthy()
+    expect(screen.getByText('Are you sure?')).toBeTruthy()
+  })
+
+  test('calls onConfirm when confirm button clicked', () => {
+    const onConfirm = vi.fn()
+    render(<ConfirmDialog {...defaultProps} onConfirm={onConfirm} />)
+    fireEvent.click(screen.getByText('Confirm'))
+    expect(onConfirm).toHaveBeenCalledOnce()
+  })
+
+  test('calls onCancel when cancel button clicked', () => {
+    const onCancel = vi.fn()
+    render(<ConfirmDialog {...defaultProps} onCancel={onCancel} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  test('uses custom button labels', () => {
+    render(<ConfirmDialog {...defaultProps} confirmLabel="Yes, delete" cancelLabel="No, keep" />)
+    expect(screen.getByText('Yes, delete')).toBeTruthy()
+    expect(screen.getByText('No, keep')).toBeTruthy()
+  })
+
+  test('danger variant has red styling', () => {
+    render(<ConfirmDialog {...defaultProps} variant="danger" />)
+    const confirmBtn = screen.getByText('Confirm')
+    expect(confirmBtn.className).toContain('bg-red-600')
+  })
+
+  test('buttons disabled when loading', () => {
+    render(<ConfirmDialog {...defaultProps} loading={true} />)
+    const confirmBtn = screen.getByText('Confirm')
+    const cancelBtn = screen.getByText('Cancel')
+    expect(confirmBtn.hasAttribute('disabled')).toBe(true)
+    expect(cancelBtn.hasAttribute('disabled')).toBe(true)
+  })
+
+  test('has aria attributes for accessibility', () => {
+    render(<ConfirmDialog {...defaultProps} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.getAttribute('aria-modal')).toBe('true')
+  })
+})

--- a/frontend/src/__tests__/StageCard.test.tsx
+++ b/frontend/src/__tests__/StageCard.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StageCard } from '../components/StageCard'
+import type { StageDetail } from '../types/api'
+
+// Mock the API client to avoid real HTTP calls
+vi.mock('../api/client', () => ({
+  getRoles: vi.fn().mockResolvedValue({ roles: {} }),
+}))
+
+describe('StageCard', () => {
+  const baseStage: StageDetail = {
+    index: 0,
+    role: 'analyst',
+    status: 'completed',
+    isRework: false,
+    reworkCycle: 0,
+    isRecovery: false,
+    toolCalls: 5,
+    policyDenies: 0,
+    turnsUsed: 3,
+    durationMs: 12000,
+    startedAt: '2026-03-28T10:00:00Z',
+    finishedAt: '2026-03-28T10:00:12Z',
+    agentUsed: 'gpt-4o',
+    result: null,
+    error: null,
+    gateResults: null,
+    denyForensics: null,
+    systemPrompt: null,
+    userPrompt: null,
+    toolCallDetails: [],
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders stage role name', () => {
+    render(<StageCard stage={baseStage} />)
+    expect(screen.getByText('analyst')).toBeTruthy()
+  })
+
+  test('renders completed status with green badge', () => {
+    render(<StageCard stage={baseStage} />)
+    const statusBadge = screen.getByText('completed')
+    expect(statusBadge.className).toContain('bg-green-800')
+  })
+
+  test('renders failed status with red badge', () => {
+    render(<StageCard stage={{ ...baseStage, status: 'failed' }} />)
+    const statusBadge = screen.getByText('failed')
+    expect(statusBadge.className).toContain('bg-red-800')
+  })
+
+  test('shows rework badge when isRework', () => {
+    render(<StageCard stage={{ ...baseStage, isRework: true, reworkCycle: 2 }} />)
+    expect(screen.getByText('Rework #2')).toBeTruthy()
+  })
+
+  test('shows recovery badge', () => {
+    render(<StageCard stage={{ ...baseStage, isRecovery: true }} />)
+    expect(screen.getByText('Recovery')).toBeTruthy()
+  })
+
+  test('displays metrics', () => {
+    render(<StageCard stage={baseStage} />)
+    expect(screen.getByText('5')).toBeTruthy() // toolCalls
+    expect(screen.getByText('0')).toBeTruthy() // policyDenies
+    expect(screen.getByText('3')).toBeTruthy() // turnsUsed
+  })
+
+  test('shows error detail when error present', () => {
+    render(<StageCard stage={{ ...baseStage, error: 'LLM timeout after 30s' }} />)
+    expect(screen.getByText('Error Detail')).toBeTruthy()
+    expect(screen.getByText('LLM timeout after 30s')).toBeTruthy()
+  })
+
+  test('shows agent model used', () => {
+    render(<StageCard stage={baseStage} />)
+    expect(screen.getByText('gpt-4o')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
16 new component tests (ConfirmDialog + StageCard). Total: 55.

## Test Plan
- [x] vitest run: 55 PASS
- [x] tsc: 0 errors